### PR TITLE
Fixes error in the console #9

### DIFF
--- a/mandelbrot-simple/Makefile
+++ b/mandelbrot-simple/Makefile
@@ -1,7 +1,7 @@
 export EMCC_DEBUG=1
 
 mandelbrot.js: mandelbrot.cpp
-	em++ --bind --std=c++11 mandelbrot.cpp -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -o mandelbrot.js
+	em++ --bind --std=c++11 mandelbrot.cpp -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s "EXTRA_EXPORTED_RUNTIME_METHODS=['addOnPostRun']" -o mandelbrot.js
 
 clean:
 	rm *.js *.wasm

--- a/mandelbrot-tiled/Makefile
+++ b/mandelbrot-tiled/Makefile
@@ -1,7 +1,7 @@
 export EMCC_DEBUG=1
 
 mandelbrot.js: mandelbrot.cpp
-	em++ --bind --std=c++11 mandelbrot.cpp -s WASM=1 -o mandelbrot.js
+	em++ --bind --std=c++11 mandelbrot.cpp -s WASM=1 -s "EXTRA_EXPORTED_RUNTIME_METHODS=['addOnPostRun']" -o mandelbrot.js
 
 clean:
 	rm *.js *.wasm


### PR DESCRIPTION
Fixes #9
adds the option -s "EXTRA_EXPORTED_RUNTIME_METHODS=['addOnPostRun']" to the Makefile to avoid the reported error
Using the following em++:
emcc (Emscripten gcc/clang-like replacement) 1.38.12 (commit c54a657cd5987cba2718f7012a55101324fde8b1)